### PR TITLE
Update tcc1014graphics.c (#113)

### DIFF
--- a/tcc1014graphics.c
+++ b/tcc1014graphics.c
@@ -82,6 +82,7 @@ static unsigned char BoarderChange=3;
 static unsigned char MasterMode=0;
 static unsigned char ColorInvert=1;
 static unsigned char BlinkState=1;
+static bool UserFlipped = false;
 static unsigned int last_mmode = 0;
 
 // BEGIN of 8 Bit render loop *****************************************************************************************
@@ -9732,7 +9733,7 @@ void SetupDisplay(void)
 		}
 		break;
 }
-	ColorInvert= (CC3Vmode & 32)>>5;
+	if(!UserFlipped) ColorInvert= (CC3Vmode & 32)>>5;
 	LinesperScreen=Lpf[VresIndex];
 	SetLinesperScreen(VresIndex);
 	VertCenter=VcenterTable[VresIndex]-4; //4 unrendered top lines
@@ -10016,6 +10017,7 @@ int GetGraphicsMode() {
 void FlipArtifacts() {
 	if (ColorInvert == 0) { ColorInvert = 1; }
 	else { ColorInvert = 0; }
+	UserFlipped = true;
 }
 /*
 unsigned char SetArtifacts(unsigned char Tmp)


### PR DESCRIPTION
If user chooses to flip artifacts, it shouldn't be undone every time VDG gets reset, which is very often in some games. Androne is a good test.

Co-authored-by: Ed Jaquay <edjjaquay@gmail.com>